### PR TITLE
Added style="direction:ltr;" to toolbar

### DIFF
--- a/addons/web_editor/static/lib/summernote/src/js/Renderer.js
+++ b/addons/web_editor/static/lib/summernote/src/js/Renderer.js
@@ -843,6 +843,8 @@ define([
       }
 
       //03 editing area
+      // TODO: add control + right shift and control + left shift to switch writing direction between RTL and LTR
+      // TODO: fix when odoo adds o_rtl and switches the views to RTL, it makes writing in RTL fine, but buggy in LTR
       var $editingArea = $('<div class="note-editing-area" />');
       //03. create editable
       var isContentEditable = !$holder.is(':disabled');
@@ -875,7 +877,8 @@ define([
       $editingArea.prependTo($editor);
 
       //06. create Toolbar
-      var $toolbar = $('<div class="note-toolbar panel-heading" />');
+      // TODO: make a RTL version of the note-toolbar of html field instead of forcing note-toolbar to stay LTR
+      var $toolbar = $('<div class="note-toolbar panel-heading" style="direction:ltr;"/>');
       for (var idx = 0, len = options.toolbar.length; idx < len; idx ++) {
         var groupName = options.toolbar[idx][0];
         var groupButtons = options.toolbar[idx][1];

--- a/addons/web_editor/static/lib/summernote/src/js/Renderer.js
+++ b/addons/web_editor/static/lib/summernote/src/js/Renderer.js
@@ -843,7 +843,7 @@ define([
       }
 
       //03 editing area
-      // TODO: add control + right shift and control + left shift to switch writing direction between RTL and LTR
+      // TODO: add summernote-rtl-plugin to switch writing direction between RTL and LTR
       // TODO: fix when odoo adds o_rtl and switches the views to RTL, it makes writing in RTL fine, but buggy in LTR
       var $editingArea = $('<div class="note-editing-area" />');
       //03. create editable


### PR DESCRIPTION
Added style="direction:ltr;" to force toolbar to stay LTR to fix buggy toolbar in RTL languagse


Description of the issue/feature this PR addresses:
when switching to an RTL language, it makes everything in RTL and adds the o_rtl CSS rule which 
messes up the toolbar 

Current behavior before PR:
HTML area is right to left, but toolbar is right to left which messes it up

Desired behavior after PR is merged:
HTML area is right to left, but toolbar is fixed to left to right



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
